### PR TITLE
A Fix for Issue #53 1.8.1 App service starts, but server does not

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -2,8 +2,8 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.opendroidphp"
-    android:versionCode="19000"
-    android:versionName="1.9.0">
+    android:versionCode="19001"
+    android:versionName="1.9.1">
 
     <uses-sdk
         android:maxSdkVersion="19"

--- a/src/org/opendroidphp/app/services/OnBootReceiver.java
+++ b/src/org/opendroidphp/app/services/OnBootReceiver.java
@@ -1,5 +1,7 @@
 package org.opendroidphp.app.services;
 
+import org.opendroidphp.app.tasks.CommandTask;
+
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -9,11 +11,23 @@ import android.preference.PreferenceManager;
 public class OnBootReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
+    	
         if (intent.getAction().equals(Intent.ACTION_BOOT_COMPLETED)) {
-            SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        	
+        	final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
             if (preferences.getBoolean("enable_server_on_boot", false)) {
-                Intent i = new Intent(context, ServerService.class);
+                
+            	Intent i = new Intent(context, ServerService.class);
                 context.startService(i);
+                
+                final boolean enableSU = preferences.getBoolean("run_as_root", false);
+                final String execName = preferences.getString("use_server_httpd", "lighttpd");
+                final String bindPort = preferences.getString("server_port", "8080");
+            	
+                CommandTask task = CommandTask.createForConnect(context, execName, bindPort, false);
+                task.enableSU(enableSU);
+                task.execute();
+                
             }
         }
         if (intent.getAction().equals(Intent.ACTION_PACKAGE_REMOVED)) {

--- a/src/org/opendroidphp/app/tasks/CommandTask.java
+++ b/src/org/opendroidphp/app/tasks/CommandTask.java
@@ -34,19 +34,30 @@ public class CommandTask extends ProgressDialogTask<String, String, String> {
     public CommandTask(Context context, String title, String message) {
         super(context, title, message);
     }
+    
+    public CommandTask(Context context, String title, String message, boolean createDialog) {
+        super(context, title, message, createDialog);
+    }
 
     public CommandTask(Context context, int titleResId, int messageResId) {
         super(context, context.getString(titleResId), context.getString(messageResId));
     }
+    
+    public CommandTask(Context context, int titleResId, int messageResId, boolean createDialog) {
+        super(context, context.getString(titleResId), context.getString(messageResId), createDialog);
+    }
 
     public static CommandTask createForConnect(final Context c, final String execName, final String bindPort) {
+    	return createForConnect(c, execName, bindPort, true);
+    }
+    public static CommandTask createForConnect(final Context c, final String execName, final String bindPort, final boolean createDialog) {
         List<String> command = Collections.unmodifiableList(new ArrayList<String>() {
             {
                 add(CHANGE_PERMISSION.concat(Constants.INTERNAL_LOCATION + "/scripts/server-sh.sh"));
                 add(String.format("%s/scripts/server-sh.sh %s %s", Constants.INTERNAL_LOCATION, execName, bindPort));
             }
         });
-        CommandTask task = new CommandTask(c, R.string.server_loading, R.string.turning_on_server);
+        CommandTask task = new CommandTask(c, R.string.server_loading, R.string.turning_on_server, createDialog);
         task.addCommand(command);
         task.setNotification(R.string.web_server_is_running);
         return task;

--- a/src/org/opendroidphp/app/tasks/ProgressDialogTask.java
+++ b/src/org/opendroidphp/app/tasks/ProgressDialogTask.java
@@ -30,23 +30,37 @@ abstract public class ProgressDialogTask<ParameterT, ProgressT, ReturnT> extends
     }
 
     public ProgressDialogTask(Context context) {
-        this.context = context;
-        handler.post(new Runnable() {
-            @Override
-            public void run() {
-                createDialog().show();
-            }
-        });
+        this(context, true);
     }
-
+    
+    public ProgressDialogTask(Context context, final boolean createDialog) {
+    	this.context = context;
+    	if(createDialog) {
+	        handler.post(new Runnable() {
+	            @Override
+	            public void run() {
+	                createDialog().show();
+	            }
+	        });
+    	}
+    }
+    
     public ProgressDialogTask(Context context, String title, String message) {
-        this(context);
+    	this(context, title, message, true);
+    }
+    
+    public ProgressDialogTask(Context context, String title, String message, boolean createDialog) {
+        this(context, createDialog);
         this.title = title;
         this.message = message;
     }
 
     public ProgressDialogTask(Context context, int titleResId, int messageResId) {
         this(context, context.getString(titleResId), context.getString(messageResId));
+    }
+    
+    public ProgressDialogTask(Context context, int titleResId, int messageResId, boolean createDialog) {
+        this(context, context.getString(titleResId), context.getString(messageResId), createDialog);
     }
 
     protected Dialog createDialog() {
@@ -73,13 +87,17 @@ abstract public class ProgressDialogTask<ParameterT, ProgressT, ReturnT> extends
 
     public ProgressDialogTask setTitle(String title) {
         this.title = title;
-        tv_title.setText(title);
+        if(tv_title != null) {
+        	tv_title.setText(title);
+        }
         return this;
     }
 
     public ProgressDialogTask setMessage(String message) {
         this.message = message;
-        tv_message.setText(message);
+        if (tv_message != null) {
+        	tv_message.setText(message);
+        }
         return this;
     }
 

--- a/src/org/opendroidphp/app/ui/HomeFragment.java
+++ b/src/org/opendroidphp/app/ui/HomeFragment.java
@@ -1,5 +1,15 @@
 package org.opendroidphp.app.ui;
 
+import java.util.List;
+
+import org.opendroidphp.R;
+import org.opendroidphp.app.Constants;
+import org.opendroidphp.app.common.utils.FileUtils;
+import org.opendroidphp.app.fragments.dialogs.DialogHelpers;
+import org.opendroidphp.app.listeners.OnInflationListener;
+import org.opendroidphp.app.services.ServerService;
+import org.opendroidphp.app.tasks.CommandTask;
+
 import android.app.Activity;
 import android.app.NotificationManager;
 import android.content.Context;
@@ -16,16 +26,6 @@ import android.view.ViewGroup;
 import android.widget.CompoundButton;
 
 import com.actionbarsherlock.app.SherlockFragment;
-
-import org.opendroidphp.R;
-import org.opendroidphp.app.Constants;
-import org.opendroidphp.app.common.utils.FileUtils;
-import org.opendroidphp.app.fragments.dialogs.DialogHelpers;
-import org.opendroidphp.app.listeners.OnInflationListener;
-import org.opendroidphp.app.services.ServerService;
-import org.opendroidphp.app.tasks.CommandTask;
-
-import java.util.List;
 
 import de.ankri.views.Switch;
 import eu.chainfire.libsuperuser.Shell;
@@ -75,8 +75,17 @@ public class HomeFragment extends SherlockFragment implements View.OnClickListen
     public void onStart() {
         super.onStart();
         if (preferences.getBoolean("enable_server_on_app_startup", false)) {
-            getSherlockActivity().
-                    startService(new Intent(getSherlockActivity(), ServerService.class));
+            
+        	Context context = getSherlockActivity();
+        	context.startService(new Intent(context, ServerService.class));
+            
+            final boolean enableSU = preferences.getBoolean("run_as_root", false);
+            final String execName = preferences.getString("use_server_httpd", "lighttpd");
+            final String bindPort = preferences.getString("server_port", "8080");
+        	
+            CommandTask task = CommandTask.createForConnect(context, execName, bindPort);
+            task.enableSU(enableSU);
+            task.execute();
         }
         new ConnectionListenerTask().execute();
     }


### PR DESCRIPTION
Make a fix for  Issue #53. The http-service will now start after Device boot.

AndroidManifest.xml change version
src\org\opendroidphp\app\services\OnBootReceiver.java modify onReceive(): execute the createForConnect CommandTask without opening a dialog
src\org\opendroidphp\app\tasks\CommandTask.java modify Constructor and static method createForConnect: add an flag for creating a dialog
src\org\opendroidphp\app\tasks\ProgressDialogTask.java modify Constructor: add an flag for creating a dialog, modify setters: add null-check
src\org\opendroidphp\app\ui\HomeFragment.java modify onStart(): execute the createForConnect CommandTask
